### PR TITLE
QC script

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,3 +55,37 @@ CLEANSER depends on something called [CmdStan](https://mc-stan.org/docs/cmdstan-
 ## Input File Format
 
 The input file has a [Matrix Market file](https://math.nist.gov/MatrixMarket/formats.html#MMformat)-esque format where the column values are `Guide ID`, `Cell ID`, and `Guide Count`, in that order.
+
+## Quality Control
+
+A command, `cleanser_qc`, that will run a script to output QC information has been included.
+
+```
+usage: cleanser_qc [-h] -i INPUT -o OUTPUT_DIRECTORY [-g GUIDE_COUNTS] [-s SAMPLES] [-t THRESHOLD]
+
+Generate CLEANSER QC information
+
+options:
+  -h, --help            show this help message and exit
+  -i INPUT, --input INPUT
+                        Cleanser posterior output file
+  -o OUTPUT_DIRECTORY, --output-directory OUTPUT_DIRECTORY
+                        Cleanser QC output directory
+  -g GUIDE_COUNTS, --guide-counts GUIDE_COUNTS
+                        Guide count file. Needed for UMI histogram and scatterplots
+  -s SAMPLES, --samples SAMPLES
+                        Cleanser sampling data. Needed for sample mean, variance, and mean histogram
+  -t THRESHOLD, --threshold THRESHOLD
+                        Disregard assignment probabilities below this value
+```
+
+`--input` and `--output-directory` are required, everything else is optional. When run including all the possible input files it will generate the following information:
+
+- MOI
+- Coverage
+- Sample means
+- A histogram of sample means
+- Sample variance
+- A scatterplot of UMI/posteriors
+- A scatterplot of UMI/posteriors with UMIs on a log2 scale
+- UMI histogram

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,12 +9,13 @@ readme = "README.md"
 requires-python = ">=3.10"
 license = { text = "MIT License" }
 classifiers = ["Programming Language :: Python :: 3"]
-dependencies = ["cmdstanpy>=1.2", "numpy>=1.26"]
+dependencies = ["cmdstanpy>=1.2", "numpy>=1.26", "matplotlib>=3.9"]
 version = "1.0"
 keywords = ["scRNA-seq", "bioinformatics"]
 
 [project.scripts]
 cleanser = "cleanser.run:run_cli"
+cleanser_qc = "cleanser_qc.run:run_cli"
 
 [tool.setuptools.packages.find]
 where = ["src"]

--- a/src/cleanser/run.py
+++ b/src/cleanser/run.py
@@ -31,7 +31,7 @@ def read_mm_file(mtx_file) -> MMLines:
 
     for line in mtx_file:
         guide, cell, count = line.strip().split()
-        mm_lines.append((int(guide), int(cell), int(count)))
+        mm_lines.append((guide, cell, int(count)))
 
     return mm_lines
 
@@ -178,13 +178,13 @@ def run_cli():
                 seed=args.seed,
             )
         )
-        output_posteriors(results, args.posteriors_output)
         if args.dc:
             output_dc_samples(results, args.so)
             output_dc_stats(results)
         elif args.cs:
             output_cs_samples(results, args.so)
             output_cs_stats(results)
+        output_posteriors(results, args.posteriors_output)
 
         print(f"Random seed: {args.seed}")
     except KeyboardInterrupt:

--- a/src/cleanser_qc/run.py
+++ b/src/cleanser_qc/run.py
@@ -1,0 +1,261 @@
+import argparse
+import csv
+from collections import defaultdict
+from dataclasses import dataclass
+from io import StringIO
+from pathlib import Path
+
+import matplotlib.pyplot as plt
+from matplotlib.figure import Figure
+
+from cleanser.run import read_mm_file, MMLines
+
+
+@dataclass
+class DCSampleMetadata:
+    "Direct capture sample information"
+
+    guide_id: str
+    r: float
+    mu: float
+    dispersion: float
+    neg_binom_mean: float
+    neg_binom_dispersion: float
+
+
+@dataclass
+class CSSampleMetadata:
+    "CROP-seq sample information"
+
+    guide_id: str
+    r: float
+    mu: float
+    dispersion: float
+    lamb: float  # lambda
+
+
+@dataclass
+class Prediction:
+    "CLEANSER Prediction for a guide/cell pair"
+    guide_id: str
+    cell_id: str
+    prediction: float
+
+
+def per_guide_sample_averages(
+    samples: list[CSSampleMetadata | DCSampleMetadata],
+) -> list[CSSampleMetadata | DCSampleMetadata]:
+
+    sample_count = len(samples)
+
+    if sample_count == 0:
+        raise ValueError("No samples")
+
+    if isinstance(samples[0], CSSampleMetadata):
+        sample_tallies = defaultdict(lambda: [0, 0.0, 0.0, 0.0, 0.0])
+        for sample in samples:
+            running_tally = sample_tallies[sample.guide_id]
+            running_tally[0] += 1
+            running_tally[1] += sample.r
+            running_tally[2] += sample.mu
+            running_tally[3] += sample.dispersion
+            running_tally[4] += sample.lamb
+
+        return [
+            CSSampleMetadata(
+                guide_id, tally[1] / tally[0], tally[2] / tally[0], tally[3] / tally[0], tally[4] / tally[0]
+            )
+            for guide_id, tally in sample_tallies.items()
+        ]
+
+    if isinstance(samples[0], DCSampleMetadata):
+        sample_tallies = defaultdict(lambda: [0, 0.0, 0.0, 0.0, 0.0, 0.0])
+        for sample in samples:
+            running_tally = sample_tallies[sample.guide_id]
+            running_tally[0] += 1
+            running_tally[1] += sample.r
+            running_tally[2] += sample.mu
+            running_tally[3] += sample.dispersion
+            running_tally[4] += sample.neg_binom_mean
+            running_tally[5] += sample.neg_binom_dispersion
+
+        return [
+            DCSampleMetadata(
+                guide_id,
+                tally[1] / tally[0],
+                tally[2] / tally[0],
+                tally[3] / tally[0],
+                tally[4] / tally[0],
+                tally[5] / tally[0],
+            )
+            for guide_id, tally in sample_tallies.items()
+        ]
+
+    raise ValueError("Invalid sample type")
+
+
+def plot_hist(values, bin_count, title="", x_label="", y_label="", density=False) -> Figure:
+    fig, ax = plt.subplots()
+
+    # the histogram of the data
+    ax.hist(values, bins=bin_count, density=density)
+
+    ax.set_xlabel(x_label)
+    ax.set_ylabel(y_label)
+    ax.set_title(title)
+
+    # Tweak spacing to prevent clipping of ylabel
+    fig.tight_layout()
+
+    return fig
+
+
+def sample_average_output(averages: list[CSSampleMetadata | DCSampleMetadata]) -> str:
+    average_text = StringIO()
+
+    if isinstance(averages[0], CSSampleMetadata):
+        average_text.write("guide\tr\tmu\tdisp\tlambda\n")
+        for ave in averages:
+            average_text.write(f"{ave.guide_id}\t{ave.r}\t{ave.mu}\t{ave.dispersion}\t{ave.lamb}\n")
+
+    if isinstance(averages[0], DCSampleMetadata):
+        average_text.write("guide\tr\tmu\tdisp\tn_mu\tn_disp\n")
+        for ave in averages:
+            average_text.write(
+                f"{ave.guide_id}\t{ave.r}\t{ave.mu}\t{ave.dispersion}\t{ave.neg_binom_mean}\t{ave.neg_binom_dispersion}\n"
+            )
+
+    return average_text.getvalue()
+
+
+def sample_average_histogram(averages: list[CSSampleMetadata | DCSampleMetadata]) -> Figure:
+    average_count = len(averages)
+
+    if average_count == 0:
+        raise ValueError("No averages")
+
+    avg_r = [a.r for a in averages]
+    fig = plot_hist(avg_r, 30, title="cleanser", x_label="sample average", y_label="count")
+    return fig
+
+
+def assigned_counts_histogram(predictions: list[Prediction], mm_lines: MMLines, threshold: float) -> Figure:
+    thresholded_preds = {(p.guide_id, p.cell_id) for p in predictions if p.prediction >= threshold}
+    umis = [umi for guide_id, cell_id, umi in mm_lines if (guide_id, cell_id) in thresholded_preds]
+    fig = plot_hist(umis, 100, title="cleanser", x_label="UMI", y_label="count")
+    return fig
+
+
+def calc_moi(predictions: list[Prediction], threshold: float) -> float:
+    cells = set()
+    predict_count = 0
+    for prediction in predictions:
+        cells.add(prediction.cell_id)
+        if prediction.prediction >= threshold:
+            predict_count += 1
+
+    return predict_count / len(cells)
+
+
+def calc_coverage(predictions: list[Prediction], threshold: float) -> float:
+    guides = set()
+    predict_count = 0
+    for prediction in predictions:
+        guides.add(prediction.guide_id)
+        if prediction.prediction >= threshold:
+            predict_count += 1
+
+    return predict_count / len(guides)
+
+
+def read_predictions(input_file) -> list[Prediction]:
+    reader = csv.reader(input_file, delimiter="\t")
+
+    return [Prediction(guide_id=l[0], cell_id=l[1], prediction=float(l[2])) for l in reader]
+
+
+def read_sample_data(sample_data_file) -> list[CSSampleMetadata | DCSampleMetadata]:
+    reader = csv.DictReader(sample_data_file, delimiter="\t")
+    if len(reader.fieldnames) == 5:
+        return [
+            CSSampleMetadata(l["guide id"], float(l["r"]), float(l["mu"]), float(l["Disp"]), float(l["lambda"]))
+            for l in reader
+        ]
+
+    if len(reader.fieldnames) == 6:
+        return [
+            DCSampleMetadata(
+                l["guide id"],
+                float(l["r"]),
+                float(l["mu"]),
+                float(l["Disp"]),
+                float(l["n_nbMean"]),
+                float(l["n_nbDisp"]),
+            )
+            for l in reader
+        ]
+
+    raise ValueError("Invalid sample data file")
+
+
+# Done: [sl601@x2-02-1 guide-mixture]$ python3 qc_scripts/moi.py qc_test/posteriors_pool1.mtx.gz 0.9
+# Done: [sl601@x2-02-1 guide-mixture]$ python3 qc_scripts/coverage.py qc_test/posteriors_pool1.mtx.gz 3343 0.1
+# Not Used: ? [sl601@x2-02-1 guide-mixture]$ python3 qc_scripts/post_thresholding.py qc_test/posteriors_pool1.mtx.gz 0.1 | gzip > qc_test/matrix.mtx.gz
+# [sl601@x2-02-1 guide-mixture]$ python3 qc_scripts/hist_assigned_counts.py qc_test/posteriors_pool1.mtx.gz qc_test/guide.mtx.gz 0.1 | gzip > qc_test/assigned_counts.mtx.gz
+# Make histogram of ^^
+# Done: [sl601@x2-02-1 samples]$ python3 ../../qc_scripts/extract_sample_avg.py > ../sample_avg.txt
+# Done: Make histogram of ^^
+# Make scatterplot of x=posterior/y=count values
+
+
+def get_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Generate CLEANSER QC information")
+    parser.add_argument("-i", "--input", type=argparse.FileType(), help="Cleanser posterior output file", required=True)
+    parser.add_argument("-o", "--output-directory", help="Cleanser QC output directory", required=True)
+    parser.add_argument("-g", "--guide-counts", type=argparse.FileType(), help="Guide count file")
+    parser.add_argument("-s", "--samples", type=argparse.FileType(), help="Cleanser sampling data")
+    parser.add_argument(
+        "-t", "--threshold", type=float, default=0.0, help="Disregard assignment probabilities below this value"
+    )
+
+    return parser.parse_args()
+
+
+def write(output_dir, filename, contents):
+    output_file = output_dir / Path(filename)
+    with open(output_file, "w", encoding="utf-8") as file:
+        file.write(contents)
+
+
+def run_cli():
+    args = get_args()
+
+    output_dir = Path(args.output_directory)
+    if not output_dir.exists():
+        output_dir.mkdir()
+    elif not output_dir.is_dir():
+        raise ValueError(f"Output directory {output_dir} must be a directory")
+
+    predictions = read_predictions(args.input)
+    moi = calc_moi(predictions, args.threshold)
+    moi_text = f"MOI: {moi}"
+    print(moi_text)
+    write(output_dir, "moi.txt", moi_text + "\n")
+
+    coverage = calc_coverage(predictions, args.threshold)
+    coverage_text = f"Coverage: {coverage}"
+    print(coverage_text)
+    write(output_dir, "coverage.txt", coverage_text + "\n")
+
+    if args.guide_counts is not None:
+        mm_lines = read_mm_file(args.guide_counts)
+        assigned_counts_histogram(predictions, mm_lines, args.threshold)
+        plt.savefig(output_dir / Path("umi_hist.png"))
+
+    if args.samples is not None:
+        samples = read_sample_data(args.samples)
+        assert len(samples) > 0
+        averages = per_guide_sample_averages(samples)
+        write(output_dir, "sample_avg.txt", sample_average_output(averages))
+        sample_average_histogram(averages)
+        plt.savefig(output_dir / Path("sample_average_hist.png"))

--- a/src/cleanser_qc/run.py
+++ b/src/cleanser_qc/run.py
@@ -245,8 +245,18 @@ def get_args() -> argparse.Namespace:
     parser = argparse.ArgumentParser(description="Generate CLEANSER QC information")
     parser.add_argument("-i", "--input", type=argparse.FileType(), help="Cleanser posterior output file", required=True)
     parser.add_argument("-o", "--output-directory", help="Cleanser QC output directory", required=True)
-    parser.add_argument("-g", "--guide-counts", type=argparse.FileType(), help="Guide count file")
-    parser.add_argument("-s", "--samples", type=argparse.FileType(), help="Cleanser sampling data")
+    parser.add_argument(
+        "-g",
+        "--guide-counts",
+        type=argparse.FileType(),
+        help="Guide count file. Needed for UMI histogram and scatterplots",
+    )
+    parser.add_argument(
+        "-s",
+        "--samples",
+        type=argparse.FileType(),
+        help="Cleanser sampling data. Needed for sample averageing and histogram",
+    )
     parser.add_argument(
         "-t", "--threshold", type=float, default=0.0, help="Disregard assignment probabilities below this value"
     )


### PR DESCRIPTION
This adds a new cleanser command that will output QC information on the results of running CLEANSER.

The QC information will be output into a directory specified at the command line and will include, in separate files:
* MOI
* Coverage
* Sample means
* A histogram of sample means
* Sample variance
* A scatterplot of UMI/posteriors
* A scatterplot of UMI/posteriors with UMIs on a log2 scale
* UMI histogram

The new command is "cleanser_qc".
```
usage: cleanser_qc [-h] -i INPUT -o OUTPUT_DIRECTORY [-g GUIDE_COUNTS] [-s SAMPLES] [-t THRESHOLD]

Generate CLEANSER QC information

options:
  -h, --help            show this help message and exit
  -i INPUT, --input INPUT
                        Cleanser posterior output file
  -o OUTPUT_DIRECTORY, --output-directory OUTPUT_DIRECTORY
                        Cleanser QC output directory
  -g GUIDE_COUNTS, --guide-counts GUIDE_COUNTS
                        Guide count file. Needed for UMI histogram and scatterplots
  -s SAMPLES, --samples SAMPLES
                        Cleanser sampling data. Needed for sample mean, variance, and mean histogram
  -t THRESHOLD, --threshold THRESHOLD
                        Disregard assignment probabilities below this value
```

![sample_mean_hist](https://github.com/siyansusan/CLEANSER/assets/719958/c5318573-7093-4c6f-912e-cfd3d9ec0109)
![umi_count_scatter_log2](https://github.com/siyansusan/CLEANSER/assets/719958/0f2bb409-9791-417d-876f-80cff8a68a92)
![umi_count_scatter](https://github.com/siyansusan/CLEANSER/assets/719958/f38e93b2-305f-4ae8-b81e-8900005596e1)
![umi_hist](https://github.com/siyansusan/CLEANSER/assets/719958/711cde10-f1a8-4bf2-b852-92ff9e2f013a)
